### PR TITLE
Setup `rake test` to run the tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development do
 	gem "rubocop", platform: :ruby
 	gem "ruby-lsp", platform: :ruby
 	gem "simplecov", platform: :ruby
+	gem "debug", ">= 1.0.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: https://github.com/joeldrapper/quickdraw.git
-  revision: 2c5929f79d1e529db2c32953a78eba063736b72a
+  revision: f1175c5835a74cd753abd5030ec1e930cb3e04b0
   specs:
     quickdraw (0.1.0)
       difftastic (~> 0.1)
@@ -23,16 +23,26 @@ GEM
     ast (2.4.2)
     backport (1.2.0)
     benchmark (0.4.0)
+    date (3.4.1)
+    debug (1.11.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.5.1)
-    difftastic (0.6.0)
+    difftastic (0.7.0)
       pretty_please
-    difftastic (0.6.0-arm64-darwin)
+    difftastic (0.7.0-arm64-darwin)
       pretty_please
     dispersion (0.2.0)
       prism
     docile (1.4.1)
     e2mmap (0.1.0)
+    erb (5.0.1)
+    io-console (0.8.0)
     io-watch (0.6.3)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     jaro_winkler (1.6.0)
     json (2.9.1)
     kramdown (2.5.1)
@@ -51,15 +61,26 @@ GEM
     parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
     pretty_please (0.2.0)
       dispersion (~> 0.2)
-    prism (1.3.0)
+    prettyprint (0.2.0)
+    prism (1.4.0)
+    psych (5.2.6)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     rbs (3.8.1)
       logger
+    rdoc (6.14.2)
+      erb
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.1)
+      io-console (~> 0.5)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.4.0)
@@ -103,6 +124,7 @@ GEM
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
     sorbet-runtime (0.5.11761)
+    stringio (3.1.7)
     thor (1.3.2)
     tilt (2.6.0)
     unicode-display_width (3.1.4)
@@ -115,6 +137,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  debug (>= 1.0.0)
   literal!
   plume!
   quickdraw!

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
+require "bundler/setup"
 require "bundler/gem_tasks"
-require "minitest/test_task"
 require "rubocop/rake_task"
 
-Minitest::TestTask.create
+desc "Run tests with quickdraw"
+task :test do
+	require "quickdraw"
+
+	Quickdraw::CLI.new(ARGV[1..]).call
+end
 
 desc "Run rubocop"
 task :rubocop do


### PR DESCRIPTION
This updates the Rakefile to allow basic running of the tests. However, I found that running the entire test suite eats up all my memory (and then some), and eventually produces errors in the Quickdraw Runner. Because it eats up a bunch of memory, it makes it hard to troubleshoot the Quickdraw error. However, the fact it consumes so much memory for what appears to be a small test suite is probably a bigger issue. The README for Quickdraw itself says it's not ready for production use, so I figured I'd leave the memory issue alone for now.

Any additional arguments are passed on to the test runner, so you can do things like `rake test -t 3 test/path/to/testfile.test.rb`.

Closes yippee-fun/plume#10